### PR TITLE
Columns with empty names will be ignored when summarizing data

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -59,6 +59,10 @@
                     value = $.trim(value);
                   }
 
+                  if (!value) {
+                    return;
+                  }
+
                   if (!Array.isArray(value)) {
                     value = [value];
                   }


### PR DESCRIPTION
@tonytlwu @squallstar 

## Issue
Fliplet/fliplet-studio#4879

## Description
If the column has empty or a name that contains only spaces it will be ignored when summarizing data.

## Screenshots/screencasts
Before: 
<img width="310" alt="Chart demo 2" src="https://user-images.githubusercontent.com/52824207/63927693-e33dff00-ca56-11e9-8545-781190a86530.png">

After:
<img width="310" alt="Chart demo 1" src="https://user-images.githubusercontent.com/52824207/63927692-e33dff00-ca56-11e9-92fb-a3366dc64246.png">

## Backward compatibility
This change is fully backward compatible.

## Notes
If this PR gets approved I will make PR for Bar, Column and Pie charts components that implement the same behavior. 