### PR TITLE
Columns with empty names will be ignored when summarizing data

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -2,7 +2,7 @@
 
   <header>
     <p>Configure your donut chart</p>
-    <a href="#">Need help?</a>
+    <a href="https://help.fliplet.com/article/62-how-to-configure-charts" target="_blank">Need help?</a>
   </header>
 
   <div class="form-horizontal">

--- a/js/build.js
+++ b/js/build.js
@@ -59,6 +59,10 @@
                     value = $.trim(value);
                   }
 
+                  if (!value) {
+                    return;
+                  }
+
                   if (!Array.isArray(value)) {
                     value = [value];
                   }


### PR DESCRIPTION
@tonytlwu @squallstar

Issue
Fliplet/fliplet-studio#4879
Fliplet/fliplet-studio#4911

Description
If the column has empty or a name that contains only spaces it will be ignored when summarizing data. Added need help link.

Backward compatibility
This change is fully backward compatible.