### PR TITLE
ID-2004 [Fix] Confirm all hooks and instance getters are working

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -416,7 +416,7 @@
       Fliplet.Hooks.on('appearanceChanged', redrawChart);
       Fliplet.Hooks.on('appearanceFileChanged', redrawChart);
 
-      refreshData().then(drawChart).catch(function(error) {
+      Fliplet().then(refreshData).then(drawChart).catch(function(error) {
         console.error(error);
         setRefreshTimer();
       });


### PR DESCRIPTION
Ref. https://weboo.atlassian.net/browse/ID-2004

`refreshData()` was being called right away, without time for the "before query" hooks be attached. This waits for the custom code to execute before loading the charts.