### PR TITLE
ID-3222 [FIX] Ensure the donut chart component's appearance settings do inherit Chart custom colors from theme's appearance settings

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -276,7 +276,11 @@ Fliplet.Widget.instance('chart-donut-1-1-0', function(data) {
             colors[index] = newColor;
             inheritColor1 = colorKey !== 'chartColor1';
             inheritColor2 = colorKey !== 'chartColor2';
-          } else if (colorKey === 'chartColor1' && inheritColor1) {
+          } else if (Fliplet.Themes.Current.get(colorKey)) {
+            colors[index] = Fliplet.Themes.Current.get(colorKey);
+          }
+
+          if (colorKey === 'chartColor1' && inheritColor1) {
             inheritColor('highlightColor', colors, index);
           } else if (colorKey === 'chartColor2' && inheritColor2) {
             inheritColor('secondaryColor', colors, index);


### PR DESCRIPTION
**Product areas affected**

Studio -> Donut Chart -> Theme appearance settings

**What does this PR do?**

Implemented code, so donut chart appears correctly after applying changes in component appearance settings

**JIRA ticket**

[ID-3222](https://weboo.atlassian.net/browse/ID-3222)

**Result**

https://github.com/Fliplet/fliplet-widget-chart-donut/assets/108272606/8f9c1547-b368-40eb-a0d9-57dd7b6f90ba

**Checklist**

None

**Testing instructions**

None

**Deployment instructions**

None

**Author concerns**

None


[ID-3222]: https://weboo.atlassian.net/browse/ID-3222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ